### PR TITLE
housekeeping

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -87,7 +87,6 @@ class Ffmpeg < Formula
       --enable-shared
       --enable-version3
       --enable-hardcoded-tables
-      --enable-avresample
       --cc=#{ENV.cc}
       --host-cflags=#{ENV.cflags}
       --host-ldflags=#{ENV.ldflags}

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -38,7 +38,6 @@ class Ffmpeg < Formula
   depends_on "libass"
   depends_on "libvorbis"
   depends_on "libvpx"
-  depends_on "opencore-amr"
   depends_on "opus"
   depends_on "rtmpdump"
   depends_on "sdl2"
@@ -69,6 +68,7 @@ class Ffmpeg < Formula
   depends_on "libssh" => :optional
   depends_on "libvidstab" => :optional
   depends_on "libvmaf" => :optional
+  depends_on "opencore-amr" => :optional
   depends_on "openh264" => :optional
   depends_on "openjpeg" => :optional
   depends_on "openssl" => :optional
@@ -85,7 +85,6 @@ class Ffmpeg < Formula
     args = %W[
       --prefix=#{prefix}
       --enable-shared
-      --enable-version3
       --enable-hardcoded-tables
       --cc=#{ENV.cc}
       --host-cflags=#{ENV.cflags}
@@ -105,8 +104,6 @@ class Ffmpeg < Formula
       --enable-libfreetype
       --enable-frei0r
       --enable-libass
-      --enable-libopencore-amrnb
-      --enable-libopencore-amrwb
       --enable-librtmp
       --enable-libspeex
       --disable-libjack
@@ -142,6 +139,12 @@ class Ffmpeg < Formula
     args << "--enable-libzimg" if build.with? "zimg"
     args << "--enable-libzmq" if build.with? "zeromq"
     args << "--enable-openssl" if build.with? "openssl"
+
+    if build.with? "opencore-amr"
+      args << "--enable-version3"
+      args << "--enable-libopencore-amrnb"
+      args << "--enable-libopencore-amrwb"
+    end
 
     if build.with? "openjpeg"
       args << "--enable-libopenjpeg"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -22,7 +22,7 @@ class Ffmpeg < Formula
   option "with-openssl", "Enable SSL support"
   option "with-rubberband", "Enable rubberband library"
   option "with-webp", "Enable using libwebp to encode WEBP images"
-  option "with-zeromq", "Enable using libzeromq to receive commands sent through a libzeromq client"
+  option "with-zeromq", "Enable using libzeromq to receive cmds sent through a libzeromq client"
   option "with-zimg", "Enable z.lib zimg library"
   option "with-srt", "Enable SRT library"
   option "with-libvmaf", "Enable libvmaf scoring library"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -85,14 +85,12 @@ class Ffmpeg < Formula
     args = %W[
       --prefix=#{prefix}
       --enable-shared
-      --enable-pthreads
       --enable-version3
       --enable-hardcoded-tables
       --enable-avresample
       --cc=#{ENV.cc}
       --host-cflags=#{ENV.cflags}
       --host-ldflags=#{ENV.ldflags}
-      --enable-ffplay
       --enable-gpl
       --enable-libaom
       --enable-libmp3lame
@@ -104,7 +102,6 @@ class Ffmpeg < Formula
       --enable-libx264
       --enable-libx265
       --enable-libxvid
-      --enable-lzma
       --enable-libfontconfig
       --enable-libfreetype
       --enable-frei0r

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -16,6 +16,7 @@ class Ffmpeg < Formula
   option "with-libssh", "Enable SFTP protocol via libssh"
   option "with-tesseract", "Enable the tesseract OCR engine"
   option "with-libvidstab", "Enable vid.stab support for video stabilization"
+  option "with-opencore-amr", "Enable Opencore AMR NR/WB audio format"
   option "with-openh264", "Enable OpenH264 library"
   option "with-openjpeg", "Enable JPEG 2000 image format"
   option "with-openssl", "Enable SSL support"


### PR DESCRIPTION
As reported by Lou Logan:
- FFmpeg’s configure file enables by default `ffplay`, `lzma` and `pthreads`
- `avresample` is deprecated
- `arm` is often not needed