### PR TITLE
WIP: add support for jack

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -49,6 +49,7 @@ class Ffmpeg < Formula
   depends_on "xz"
 
   unless OS.mac?
+    depends_on "jack" => :optional
     depends_on "zlib"
     depends_on "bzip2"
     depends_on "linuxbrew/xorg/libxv"
@@ -105,11 +106,11 @@ class Ffmpeg < Formula
       --enable-libfreetype
       --enable-frei0r
       --enable-libass
-      --disable-libjack
-      --disable-indev=jack
     ]
 
     if OS.mac?
+      args << "--disable-libjack"
+      args << "--disable-indev=jack"
       args << "--enable-opencl"
       args << "--enable-videotoolbox"
     end
@@ -141,6 +142,11 @@ class Ffmpeg < Formula
     args << "--enable-libzimg" if build.with? "zimg"
     args << "--enable-libzmq" if build.with? "zeromq"
     args << "--enable-openssl" if build.with? "openssl"
+
+    if build.with? "jack"
+      args << "--enable-libjack"
+      args << "--enable-indev=jack"
+    end
 
     # packages that need additional license options
     if build.with?("opencore-amr") || build.with?("libvmaf")


### PR DESCRIPTION
This one does not work yet. It fails to find the `jack.pc` file, and jack does not seem to be in the PKG_CONFIG path:

```
2019-02-19 09:00:28 +0100

./configure
--prefix=/home/linuxbrew/.linuxbrew/Cellar/ffmpeg/4.1.1-with-options
--enable-shared
--enable-pthreads
--enable-version3
--enable-hardcoded-tables
--enable-avresample
--cc=gcc-8
--host-cflags=
--host-ldflags=
--enable-ffplay
--enable-gpl
--enable-libaom
--enable-libmp3lame
--enable-libopus
--enable-libsnappy
--enable-libtheora
--enable-libvorbis
--enable-libvpx
--enable-libx264
--enable-libx265
--enable-libxvid
--enable-lzma
--enable-libfontconfig
--enable-libfreetype
--enable-frei0r
--enable-libass
--enable-libopencore-amrnb
--enable-libopencore-amrwb
--enable-librtmp
--enable-libspeex
--disable-htmlpages
--enable-chromaprint
--enable-libbluray
--enable-libbs2b
--enable-libcaca
--enable-libfdk-aac
--enable-libgme
--enable-libmodplug
--enable-libopenh264
--enable-librsvg
--enable-librubberband
--enable-libsoxr
--enable-libsrt
--enable-libssh
--enable-libtesseract
--enable-libtwolame
--enable-libvidstab
--enable-libwavpack
--enable-libwebp
--enable-libzimg
--enable-libzmq
--enable-openssl
--enable-libjack
--enable-indev=jack
--enable-libopenjpeg
--disable-decoder=jpeg2000
--extra-cflags=-I/home/linuxbrew/.linuxbrew/Cellar/openjpeg/2.3.0/include/openjpeg-2.3
--enable-nonfree

ERROR: jack not found using pkg-config

If you think configure made a mistake, make sure you are using the latest
version from Git.  If the latest version fails, report the problem to the
ffmpeg-user@ffmpeg.org mailing list or IRC #ffmpeg on irc.freenode.net.
Include the log file "ffbuild/config.log" produced by configure as this will help
solve the problem.

HOMEBREW_VERSION: 2.0.2-2-gef5366d
ORIGIN: https://github.com/Homebrew/brew
HEAD: ef5366dac56b818a2cc434e46b0c3765bf895780
Last commit: 13 hours ago
Core tap ORIGIN: https://github.com/Linuxbrew/homebrew-core
Core tap HEAD: 07ba250d30af905139108f363d7bf622ee173f2c
Core tap last commit: 12 hours ago
HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew
HOMEBREW_CACHE: /home/werner/.cache/Homebrew
CPU: octa-core 64-bit skylake
Homebrew Ruby: 2.3.7 => /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/bin/ruby
Clang: N/A
Git: 2.19.1 => /usr/bin/git
Curl: 7.61.0 => /usr/bin/curl
Kernel: Linux 4.18.0-13-generic x86_64 GNU/Linux
OS: Ubuntu 18.10 (cosmic)
Host glibc: 2.28
/usr/bin/gcc: 8.2.0
glibc: N/A
gcc: 5.5.0_4
xorg: N/A

HOMEBREW_CC: gcc-8
HOMEBREW_CXX: g++-8
MAKEFLAGS: -j8
CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew/opt/isl@0.18:/home/linuxbrew/.linuxbrew
PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/aom/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/zlib/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libpng/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/freetype/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libbsd/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/expat/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/ncurses/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/openssl/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/readline/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/sqlite/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/python@2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/util-linux/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/fontconfig/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/frei0r/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/fribidi/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libffi/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/pcre/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/glib/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/pixman/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libpthread-stubs/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxau/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxdmcp/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxcb/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libx11/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxext/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxrender/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/cairo/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/graphite2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/icu4c/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/harfbuzz/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libass/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libogg/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libvorbis/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libvpx/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/opencore-amr/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/opus/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/rtmpdump/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libice/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxfixes/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxcursor/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxscrnsaver/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxxf86vm/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxi/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxinerama/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxrandr/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/json-c/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/flac/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libsndfile/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libsoxr/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/speexdsp/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libcap/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/pulseaudio/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/sdl2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/speex/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/theora/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/x264/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/x265/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/xz/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxv/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/chromaprint/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/fdk-aac/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/game-music-emu/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/python/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libxml2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libbluray/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libbs2b/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libcaca/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libmodplug/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/jpeg/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libtiff/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/gdk-pixbuf/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libcroco/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/pango/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/librsvg/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libssh/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libvidstab/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/openh264/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/little-cms2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/openjpeg/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libsamplerate/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/mpfr/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/isl@0.18/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libevent/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/open-mpi/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/fftw/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/vamp-plugin-sdk/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/rubberband/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/srt/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/webp/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/leptonica/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/tesseract/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/two-lame/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/wavpack/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/zeromq/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/zimg/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/xorgproto/share/pkgconfig:/home/linuxbrew/.linuxbrew/opt/shared-mime-info/share/pkgconfig
HOMEBREW_GIT: git
ACLOCAL_PATH: /home/linuxbrew/.linuxbrew/share/aclocal
PATH: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super:/home/linuxbrew/.linuxbrew/opt/nasm/bin:/home/linuxbrew/.linuxbrew/opt/pkg-config/bin:/home/linuxbrew/.linuxbrew/opt/texi2html/bin:/home/linuxbrew/.linuxbrew/opt/aom/bin:/home/linuxbrew/.linuxbrew/opt/libpng/bin:/home/linuxbrew/.linuxbrew/opt/bzip2/bin:/home/linuxbrew/.linuxbrew/opt/freetype/bin:/home/linuxbrew/.linuxbrew/opt/expat/bin:/home/linuxbrew/.linuxbrew/opt/ncurses/bin:/home/linuxbrew/.linuxbrew/opt/gdbm/bin:/home/linuxbrew/.linuxbrew/opt/openssl/bin:/home/linuxbrew/.linuxbrew/opt/sqlite/bin:/home/linuxbrew/.linuxbrew/opt/python@2/bin:/home/linuxbrew/.linuxbrew/opt/util-linux/bin:/home/linuxbrew/.linuxbrew/opt/fontconfig/bin:/home/linuxbrew/.linuxbrew/opt/lame/bin:/home/linuxbrew/.linuxbrew/opt/fribidi/bin:/home/linuxbrew/.linuxbrew/opt/gettext/bin:/home/linuxbrew/.linuxbrew/opt/pcre/bin:/home/linuxbrew/.linuxbrew/opt/glib/bin:/home/linuxbrew/.linuxbrew/opt/cairo/bin:/home/linuxbrew/.linuxbrew/opt/graphite2/bin:/home/linuxbrew/.linuxbrew/opt/icu4c/bin:/home/linuxbrew/.linuxbrew/opt/harfbuzz/bin:/home/linuxbrew/.linuxbrew/opt/rtmpdump/bin:/home/linuxbrew/.linuxbrew/opt/xinput/bin:/home/linuxbrew/.linuxbrew/opt/flac/bin:/home/linuxbrew/.linuxbrew/opt/libsndfile/bin:/home/linuxbrew/.linuxbrew/opt/libtool/bin:/home/linuxbrew/.linuxbrew/opt/pulseaudio/bin:/home/linuxbrew/.linuxbrew/opt/sdl2/bin:/home/linuxbrew/.linuxbrew/opt/x264/bin:/home/linuxbrew/.linuxbrew/opt/x265/bin:/home/linuxbrew/.linuxbrew/opt/xz/bin:/home/linuxbrew/.linuxbrew/opt/fdk-aac/bin:/home/linuxbrew/.linuxbrew/opt/python/bin:/home/linuxbrew/.linuxbrew/opt/libxml2/bin:/home/linuxbrew/.linuxbrew/opt/libbluray/bin:/home/linuxbrew/.linuxbrew/opt/libbs2b/bin:/home/linuxbrew/.linuxbrew/opt/libcaca/bin:/home/linuxbrew/.linuxbrew/opt/jpeg/bin:/home/linuxbrew/.linuxbrew/opt/libtiff/bin:/home/linuxbrew/.linuxbrew/opt/shared-mime-info/bin:/home/linuxbrew/.linuxbrew/opt/gdk-pixbuf/bin:/home/linuxbrew/.linuxbrew/opt/libcroco/bin:/home/linuxbrew/.linuxbrew/opt/pango/bin:/home/linuxbrew/.linuxbrew/opt/librsvg/bin:/home/linuxbrew/.linuxbrew/opt/little-cms2/bin:/home/linuxbrew/.linuxbrew/opt/openjpeg/bin:/home/linuxbrew/.linuxbrew/opt/libsamplerate/bin:/home/linuxbrew/.linuxbrew/opt/ladspa-sdk/bin:/home/linuxbrew/.linuxbrew/opt/gcc/bin:/home/linuxbrew/.linuxbrew/opt/libevent/bin:/home/linuxbrew/.linuxbrew/opt/open-mpi/bin:/home/linuxbrew/.linuxbrew/opt/fftw/bin:/home/linuxbrew/.linuxbrew/opt/vamp-plugin-sdk/bin:/home/linuxbrew/.linuxbrew/opt/openjdk/bin:/home/linuxbrew/.linuxbrew/opt/rubberband/bin:/home/linuxbrew/.linuxbrew/opt/srt/bin:/home/linuxbrew/.linuxbrew/opt/giflib/bin:/home/linuxbrew/.linuxbrew/opt/webp/bin:/home/linuxbrew/.linuxbrew/opt/leptonica/bin:/home/linuxbrew/.linuxbrew/opt/tesseract/bin:/home/linuxbrew/.linuxbrew/opt/wavpack/bin:/home/linuxbrew/.linuxbrew/opt/zeromq/bin:/home/linuxbrew/.linuxbrew/opt/berkeley-db/bin:/home/linuxbrew/.linuxbrew/opt/jack/bin:/home/linuxbrew/.linuxbrew/opt/binutils/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

I can find it here though:

```
/home/linuxbrew/.linuxbrew/Cellar/jack/0.125.0_3/lib64/pkgconfig/jack.pc
```

Not sure what to do to correct the path...