### PR TITLE
Revert "ffmpeg 4.1.4"

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -1,9 +1,9 @@
 class Ffmpeg < Formula
   desc "Play, record, convert, and stream audio and video"
   homepage "https://ffmpeg.org/"
-  url "https://ffmpeg.org/releases/ffmpeg-4.1.4.tar.xz"
-  version "4.1.4-with-options" # to distinguish from homebrew-core's ffmpeg
-  sha256 "f1f049a82fcfbf156564e73a3935d7e750891fab2abf302e735104fd4050a7e1"
+  url "https://ffmpeg.org/releases/ffmpeg-4.1.3.tar.xz"
+  version "4.1.3-with-options" # to distinguish from homebrew-core's ffmpeg
+  sha256 "0c3020452880581a8face91595b239198078645e7d7184273b8bcc7758beb63d"
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   # This formula is for people that will compile with their chosen options


### PR DESCRIPTION
Reverts varenc/homebrew-ffmpeg#31 because https://github.com/varenc/homebrew-ffmpeg/issues/32.