### PR TITLE
Add workaround for Xcode 11 clang bug

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -87,6 +87,11 @@ class Ffmpeg < Formula
   depends_on "zimg" => :optional
 
   def install
+    # Work around Xcode 11 clang bug
+    # https://bitbucket.org/multicoreware/x265/issues/514/wrong-code-generated-on-macos-1015
+    # https://trac.ffmpeg.org/ticket/8073
+    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
+
     args = %W[
       --prefix=#{prefix}
       --enable-shared


### PR DESCRIPTION
Currently ffmpeg segfaults on macOS 10.15, see https://trac.ffmpeg.org/ticket/8073
(taken from https://github.com/Homebrew/homebrew-core/commit/48dbe831a29547f70509592e0fbd6592a511da60#diff-8f4deb87ce96b9c5efe97be3288bb406)